### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release-milestone.yml
+++ b/.github/workflows/release-milestone.yml
@@ -36,7 +36,7 @@ jobs:
       env:
         PROJECT_VERSION: ${{ env.PROJECT_VERSION }}
       run: |
-        echo "::set-output name=project-version::$PROJECT_VERSION"
+        echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
   # build fatjar as it's only needed once from a linux
   jar:


### PR DESCRIPTION
## Description

Resolve  #81 

Update `.github/workflows/release-milestone.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
    echo "::set-output name=project-version::$PROJECT_VERSION"
```

**TO-BE**

```yml
run: |
    echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
```